### PR TITLE
Fix Tic-tac-toe game logic

### DIFF
--- a/js-pkg/demos/src/pages/tictactoe.tsx
+++ b/js-pkg/demos/src/pages/tictactoe.tsx
@@ -70,7 +70,7 @@ function ticTacToeReducer(state: GameState, action: ActionType): GameState {
             ]
             for (let i = 0; i < lines.length; i++) {
                 const [a, b, c] = lines[i]
-                if (state.board[a] && state.board[a] === state.board[b] && state.board[a] === state.board[c]) {
+                if (state.board[a] !== null && state.board[a] === state.board[b] && state.board[a] === state.board[c]) {
                     winner = state.board[a]
                 }
             }


### PR DESCRIPTION
Previously, Player "O" could never win because there was a null check of `state.board[a]` but since `Player.O` was represented by a 0 value enum, this condition was false. Replaced with an explicit null check.