### PR TITLE
Extract JS from React lib

### DIFF
--- a/docs/src/pages/index.md
+++ b/docs/src/pages/index.md
@@ -74,11 +74,11 @@ export default function SliderDemo() {
 }
 ```
 
-All messages in DriftDB belong to a **room**, and have a **subject**. Rooms and subjects are both represented by strings. Rooms are represented by a unique generated string of characters. Subjects are chosen by the developer and usually have a meaning in the context of the application. In the example above, `slider` is the name of the subject used for synchronizing the state of the range slider input.
+All messages in DriftDB belong to a **room**, and have a **key**. Rooms and keys are both represented by strings. Rooms are represented by a unique generated string of characters. Subjects are chosen by the developer and usually have a meaning in the context of the application. In the example above, `slider` is the name of the key used for synchronizing the state of the range slider input.
 
 The room in the example above depends on whether the user visits the page directly or via a link that includes a room ID. If the user visits the page directly, a new room ID is generated and inserted into the URL. If another user opens the same URL, they will be connected to the same room, and instantly be sharing state. This is not behavior of DriftDB itself, but of the `DriftDBProvider` React component used as a client.
 
-A connection with the server is scoped to a **room**. Messages to multiple subjects (within the same room) are multiplexed over one connection.
+A connection with the server is scoped to a **room**. Messages to multiple keys (within the same room) are multiplexed over one connection.
 
 For more details on DriftDB-React, see [the React docs](/docs/react) or [this four-minute tutorial video](https://www.youtube.com/watch?v=ktb6HUZlyJs).
 

--- a/js-pkg/driftdb-react/src/index.tsx
+++ b/js-pkg/driftdb-react/src/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { DbConnection, MAX_PRESENCE_INTERVAL, PresenceListener, PresenceMessage, StateListener, uniqueClientId, WrappedPresenceMessage } from "driftdb"
+import { DbConnection, PresenceListener, StateListener, uniqueClientId, WrappedPresenceMessage } from "driftdb"
 import { Api, RoomResult } from "driftdb/dist/api"
 import { ConnectionStatus, SequenceValue } from "driftdb/dist/types";
 

--- a/js-pkg/driftdb/src/index.ts
+++ b/js-pkg/driftdb/src/index.ts
@@ -1,5 +1,7 @@
 import { ConnectionStatus, MessageFromDb, MessageToDb, SequenceValue, Key } from "./types"
 
+const CLIENT_ID_KEY = "_driftdb_client_id"
+
 export class EventListener<T> {
     listeners: Array<(event: T) => void> = []
 
@@ -205,6 +207,133 @@ export class DbConnection {
         this.subscriptions.unsubscribe(subject, listener)
         if (sizeCallback) {
             this.sizeSubscriptions.unsubscribe(subject, sizeCallback)
+        }
+    }
+}
+
+export class StateListener<T> {
+    lastUpdateSent: number = 0
+    lastValue: T | null = null
+    debounceTimeout: number | null = null
+
+    constructor(
+        private callback: (value: T) => void,
+        private db: DbConnection,
+        private key: string,
+        private debounceMillis: number = 50
+    ) {
+        this.callback = callback.bind(this)
+        this.setStateOptimistic = this.setStateOptimistic.bind(this)
+        this.sendUpdate = this.sendUpdate.bind(this)
+
+        db.subscribe(key, (value: SequenceValue) => {
+            this.callback(value.value as T)
+        })
+    }
+
+    onMessage(value: SequenceValue) {
+        this.callback(value.value as T)
+    }
+
+    sendUpdate() {
+        if (this.debounceTimeout !== null) {
+            window.clearTimeout(this.debounceTimeout)
+            this.debounceTimeout = null
+        }
+        this.db?.send({
+            type: "push",
+            action: { "type": "replace" },
+            value: this.lastValue,
+            key: this.key
+        })
+    }
+
+    setStateOptimistic(value: T) {
+        this.callback(value)
+
+        this.lastValue = value
+        const now = performance.now()
+        if (now - this.lastUpdateSent < this.debounceMillis) {
+            if (this.debounceTimeout === null) {
+                this.debounceTimeout = window.setTimeout(this.sendUpdate, this.debounceMillis)
+            }
+        } else {
+            this.lastUpdateSent = now
+            this.sendUpdate()
+        }
+    }
+}
+
+export function uniqueClientId(): string {
+    if (sessionStorage.getItem(CLIENT_ID_KEY)) {
+        return sessionStorage.getItem(CLIENT_ID_KEY)!
+    } else {
+        let clientId = crypto.randomUUID()
+        sessionStorage.setItem(CLIENT_ID_KEY, clientId)
+        return clientId
+    }
+}
+
+export interface PresenceMessage<T> {
+    client: string
+    value: T
+}
+
+export type WrappedPresenceMessage<T> = {
+    value: T,
+    lastSeen: number
+}
+
+export const MIN_PRESENCE_INTERVAL = 100
+export const MAX_PRESENCE_INTERVAL = 1_000
+
+export class PresenceListener<T> {
+    // Time of the last update caused by a state change (not regular interval).
+    private lastUpdate = 0
+    
+    // True if we have a pending update.
+    private nextUpdate: number
+
+    private updateHandle: ReturnType<typeof setTimeout>
+
+    constructor(private state: T, private db: DbConnection, private key: string, private clientId: string) {
+        this.nextUpdate = Date.now()
+
+        this.updateHandle = setTimeout(() => {            
+            this.update()
+        }, 0)
+    }
+
+    private update() {
+        this.db.send({
+            type: "push",
+            action: { type: "relay" },
+            value: { value: this.state, client: this.clientId },
+            key: this.key
+        })
+
+        this.nextUpdate = Date.now() + MAX_PRESENCE_INTERVAL
+        this.lastUpdate = Date.now()
+        this.updateHandle = setTimeout(() => {
+            this.update()
+        }, MAX_PRESENCE_INTERVAL)        
+    }
+
+    updateState(value: T) {
+        if (JSON.stringify(value) === JSON.stringify(this.state)) {
+            return
+        }
+
+        this.state = value
+        
+        const nextUpdate = this.lastUpdate + MIN_PRESENCE_INTERVAL
+
+        if (nextUpdate < this.nextUpdate) {
+            this.nextUpdate = nextUpdate
+            clearTimeout(this.updateHandle)
+            this.updateHandle = setTimeout(() => {
+                this.update()
+            }, this.nextUpdate - Date.now())
         }
     }
 }

--- a/js-pkg/driftdb/src/index.ts
+++ b/js-pkg/driftdb/src/index.ts
@@ -2,6 +2,7 @@ import { LatencyTest } from "./latency"
 import { ConnectionStatus, MessageFromDb, MessageToDb, SequenceValue, Key } from "./types"
 export { PresenceListener, WrappedPresenceMessage, PresenceMessage } from "./presence"
 export { StateListener } from "./state"
+export { Reducer } from "./reducer"
 
 const CLIENT_ID_KEY = "_driftdb_client_id"
 

--- a/js-pkg/driftdb/src/index.ts
+++ b/js-pkg/driftdb/src/index.ts
@@ -1,4 +1,7 @@
+import { LatencyTest } from "./latency"
 import { ConnectionStatus, MessageFromDb, MessageToDb, SequenceValue, Key } from "./types"
+export { PresenceListener, WrappedPresenceMessage, PresenceMessage } from "./presence"
+export { StateListener } from "./state"
 
 const CLIENT_ID_KEY = "_driftdb_client_id"
 
@@ -49,30 +52,6 @@ export class SubscriptionManager<T> {
 
         const subscription = this.subscriptions.get(key)!
         subscription.dispatch(event)
-    }
-}
-
-export class LatencyTest {
-    private startTime: number
-    private endTime: number | null = null
-    private signal: Promise<void>
-    private resolve!: () => void
-
-    constructor() {
-        this.startTime = performance.now()
-        this.signal = new Promise((resolve) => {
-            this.resolve = resolve
-        })
-    }
-
-    receivedResponse() {
-        this.endTime = performance.now()
-        this.resolve()
-    }
-
-    async result() {
-        await this.signal
-        return this.endTime! - this.startTime
     }
 }
 
@@ -211,59 +190,6 @@ export class DbConnection {
     }
 }
 
-export class StateListener<T> {
-    lastUpdateSent: number = 0
-    lastValue: T | null = null
-    debounceTimeout: number | null = null
-
-    constructor(
-        private callback: (value: T) => void,
-        private db: DbConnection,
-        private key: string,
-        private debounceMillis: number = 50
-    ) {
-        this.callback = callback.bind(this)
-        this.setStateOptimistic = this.setStateOptimistic.bind(this)
-        this.sendUpdate = this.sendUpdate.bind(this)
-
-        db.subscribe(key, (value: SequenceValue) => {
-            this.callback(value.value as T)
-        })
-    }
-
-    onMessage(value: SequenceValue) {
-        this.callback(value.value as T)
-    }
-
-    sendUpdate() {
-        if (this.debounceTimeout !== null) {
-            window.clearTimeout(this.debounceTimeout)
-            this.debounceTimeout = null
-        }
-        this.db?.send({
-            type: "push",
-            action: { "type": "replace" },
-            value: this.lastValue,
-            key: this.key
-        })
-    }
-
-    setStateOptimistic(value: T) {
-        this.callback(value)
-
-        this.lastValue = value
-        const now = performance.now()
-        if (now - this.lastUpdateSent < this.debounceMillis) {
-            if (this.debounceTimeout === null) {
-                this.debounceTimeout = window.setTimeout(this.sendUpdate, this.debounceMillis)
-            }
-        } else {
-            this.lastUpdateSent = now
-            this.sendUpdate()
-        }
-    }
-}
-
 export function uniqueClientId(): string {
     if (sessionStorage.getItem(CLIENT_ID_KEY)) {
         return sessionStorage.getItem(CLIENT_ID_KEY)!
@@ -271,130 +197,5 @@ export function uniqueClientId(): string {
         let clientId = crypto.randomUUID()
         sessionStorage.setItem(CLIENT_ID_KEY, clientId)
         return clientId
-    }
-}
-
-export interface PresenceMessage<T> {
-    client: string
-    value: T
-}
-
-export type WrappedPresenceMessage<T> = {
-    value: T,
-    lastSeen: number
-}
-
-interface PresenceListenerOptions<T> {
-    initialState: T,
-    db: DbConnection,
-    clientId: string,
-    key?: string,
-    callback?: (presence: Record<string, WrappedPresenceMessage<T>>) => void,
-    minPresenceInterval?: number,
-    maxPresenceInterval?: number,
-}
-
-export class PresenceListener<T> {
-    private state: T
-    private key: string
-    private clientId: string
-    private db: DbConnection
-    private callback: (presence: Record<string, WrappedPresenceMessage<T>>) => void
-    private presence: Record<string, WrappedPresenceMessage<T>> = {}
-    private interval: ReturnType<typeof setInterval>
-    private minPresenceInterval: number
-    private maxPresenceInterval: number
-
-    // Time of the last update caused by a state change.
-    private lastUpdate = 0
-
-    // True if we have a pending update.
-    private nextUpdate: number
-
-    private updateHandle: ReturnType<typeof setTimeout>
-
-    constructor(options: PresenceListenerOptions<T>) {
-        this.nextUpdate = Date.now()
-
-        this.state = options.initialState
-        this.db = options.db
-        this.key = options.key ?? "__presence"
-        this.clientId = options.clientId
-        this.callback = options.callback ?? (() => { })
-
-        this.minPresenceInterval = options.minPresenceInterval ?? 20 // 20 ms
-        this.maxPresenceInterval = options.maxPresenceInterval ?? 1_000 // 1 second
-
-        this.updateHandle = setTimeout(() => {
-            this.update()
-        }, 0)
-
-        this.onMessage = this.onMessage.bind(this)
-        this.db.subscribe(this.key, this.onMessage)
-
-        this.interval = setInterval(() => {
-            for (let client in this.presence) {
-                if (Date.now() - this.presence[client].lastSeen > this.maxPresenceInterval * 2) {
-                    delete this.presence[client]
-                }
-            }
-        }, this.maxPresenceInterval)
-    }
-
-    destroy() {
-        clearInterval(this.interval)
-        clearTimeout(this.updateHandle)
-        this.db.unsubscribe(this.key, this.onMessage)
-    }
-
-    private onMessage(event: SequenceValue) {
-        let message: PresenceMessage<T> = event.value as any
-        if (message.client === this.clientId) {
-            // Ignore our own messages.
-            return
-        }
-
-        this.presence = {
-            ...this.presence,
-            [message.client]: {
-                value: message.value,
-                lastSeen: Date.now()
-            }
-        }
-
-        this.callback(this.presence)
-    }
-
-    private update() {
-        this.db.send({
-            type: "push",
-            action: { type: "relay" },
-            value: { value: this.state, client: this.clientId },
-            key: this.key
-        })
-
-        this.nextUpdate = Date.now() + this.maxPresenceInterval
-        this.lastUpdate = Date.now()
-        this.updateHandle = setTimeout(() => {
-            this.update()
-        }, this.maxPresenceInterval)
-    }
-
-    updateState(value: T) {
-        if (JSON.stringify(value) === JSON.stringify(this.state)) {
-            return
-        }
-
-        this.state = value
-
-        const nextUpdate = this.lastUpdate + this.minPresenceInterval
-
-        if (nextUpdate < this.nextUpdate) {
-            this.nextUpdate = nextUpdate
-            clearTimeout(this.updateHandle)
-            this.updateHandle = setTimeout(() => {
-                this.update()
-            }, this.nextUpdate - Date.now())
-        }
     }
 }

--- a/js-pkg/driftdb/src/latency.ts
+++ b/js-pkg/driftdb/src/latency.ts
@@ -1,0 +1,23 @@
+export class LatencyTest {
+    private startTime: number
+    private endTime: number | null = null
+    private signal: Promise<void>
+    private resolve!: () => void
+
+    constructor() {
+        this.startTime = performance.now()
+        this.signal = new Promise((resolve) => {
+            this.resolve = resolve
+        })
+    }
+
+    receivedResponse() {
+        this.endTime = performance.now()
+        this.resolve()
+    }
+
+    async result() {
+        await this.signal
+        return this.endTime! - this.startTime
+    }
+}

--- a/js-pkg/driftdb/src/presence.ts
+++ b/js-pkg/driftdb/src/presence.ts
@@ -1,0 +1,127 @@
+import { DbConnection } from "."
+import { SequenceValue } from "./types"
+
+export interface PresenceMessage<T> {
+    client: string
+    value: T
+}
+
+export type WrappedPresenceMessage<T> = {
+    value: T,
+    lastSeen: number
+}
+
+interface PresenceListenerOptions<T> {
+    initialState: T,
+    db: DbConnection,
+    clientId: string,
+    key?: string,
+    callback?: (presence: Record<string, WrappedPresenceMessage<T>>) => void,
+    minPresenceInterval?: number,
+    maxPresenceInterval?: number,
+}
+
+export class PresenceListener<T> {
+    private state: T
+    private key: string
+    private clientId: string
+    private db: DbConnection
+    private callback: (presence: Record<string, WrappedPresenceMessage<T>>) => void
+    private presence: Record<string, WrappedPresenceMessage<T>> = {}
+    private interval: ReturnType<typeof setInterval>
+    private minPresenceInterval: number
+    private maxPresenceInterval: number
+
+    // Time of the last update caused by a state change.
+    private lastUpdate = 0
+
+    // True if we have a pending update.
+    private nextUpdate: number
+
+    private updateHandle: ReturnType<typeof setTimeout>
+
+    constructor(options: PresenceListenerOptions<T>) {
+        this.nextUpdate = Date.now()
+
+        this.state = options.initialState
+        this.db = options.db
+        this.key = options.key ?? "__presence"
+        this.clientId = options.clientId
+        this.callback = options.callback ?? (() => { })
+
+        this.minPresenceInterval = options.minPresenceInterval ?? 20 // 20 ms
+        this.maxPresenceInterval = options.maxPresenceInterval ?? 1_000 // 1 second
+
+        this.updateHandle = setTimeout(() => {
+            this.update()
+        }, 0)
+
+        this.onMessage = this.onMessage.bind(this)
+        this.db.subscribe(this.key, this.onMessage)
+
+        this.interval = setInterval(() => {
+            for (let client in this.presence) {
+                if (Date.now() - this.presence[client].lastSeen > this.maxPresenceInterval * 2) {
+                    delete this.presence[client]
+                }
+            }
+        }, this.maxPresenceInterval)
+    }
+
+    destroy() {
+        clearInterval(this.interval)
+        clearTimeout(this.updateHandle)
+        this.db.unsubscribe(this.key, this.onMessage)
+    }
+
+    private onMessage(event: SequenceValue) {
+        let message: PresenceMessage<T> = event.value as any
+        if (message.client === this.clientId) {
+            // Ignore our own messages.
+            return
+        }
+
+        this.presence = {
+            ...this.presence,
+            [message.client]: {
+                value: message.value,
+                lastSeen: Date.now()
+            }
+        }
+
+        this.callback(this.presence)
+    }
+
+    private update() {
+        this.db.send({
+            type: "push",
+            action: { type: "relay" },
+            value: { value: this.state, client: this.clientId },
+            key: this.key
+        })
+
+        this.nextUpdate = Date.now() + this.maxPresenceInterval
+        this.lastUpdate = Date.now()
+        this.updateHandle = setTimeout(() => {
+            this.update()
+        }, this.maxPresenceInterval)
+    }
+
+    updateState(value: T) {
+        if (JSON.stringify(value) === JSON.stringify(this.state)) {
+            return
+        }
+
+        this.state = value
+
+        const nextUpdate = this.lastUpdate + this.minPresenceInterval
+
+        if (nextUpdate < this.nextUpdate) {
+            this.nextUpdate = nextUpdate
+            clearTimeout(this.updateHandle)
+            this.updateHandle = setTimeout(() => {
+                this.update()
+            }, this.nextUpdate - Date.now())
+        }
+    }
+}

--- a/js-pkg/driftdb/src/reducer.ts
+++ b/js-pkg/driftdb/src/reducer.ts
@@ -2,11 +2,22 @@ import { DbConnection } from "."
 import { SequenceValue } from "./types"
 
 export interface ReducerOpts<T, A> {
+    /** A key identifying the stream to use for the reducer. */
     key: string,
+
+    /** The reducer function applied when dispatch is called. */
     reducer: (state: T, action: A) => T,
+
+    /** The initial state passed to the reducer. */
     initialValue: T,
+
+    /** The number of messages to keep in the stream before compacting. */
     sizeThreshold?: number,
+
+    /** The database connection to use. */
     db: DbConnection,
+
+    /** A callback function called when the state changes, either because of a local call to dispatch or a remote event. */
     callback: (state: T) => void
 }
 
@@ -58,14 +69,16 @@ export class Reducer<T, A> {
         if (value.reset !== undefined) {
             this.lastConfirmedState = value.reset as T;
             this.lastConfirmedSeq = sequenceValue.seq;
-            this.callback(structuredClone(this.lastConfirmedState.current));
+            this.state = structuredClone(this.lastConfirmedState);
+            this.callback(this.state);
             return;
         }
 
         if (value.apply !== undefined) {
             this.lastConfirmedState = this.reducer(this.lastConfirmedState, value.apply as A);
             this.lastConfirmedSeq = sequenceValue.seq;
-            this.callback(structuredClone(this.lastConfirmedState));
+            this.state = structuredClone(this.lastConfirmedState);
+            this.callback(this.state);
             return;
         }
 

--- a/js-pkg/driftdb/src/reducer.ts
+++ b/js-pkg/driftdb/src/reducer.ts
@@ -1,0 +1,85 @@
+import { DbConnection } from "."
+import { SequenceValue } from "./types"
+
+export interface ReducerOpts<T, A> {
+    key: string,
+    reducer: (state: T, action: A) => T,
+    initialValue: T,
+    sizeThreshold?: number,
+    db: DbConnection,
+    callback: (state: T) => void
+}
+
+export class Reducer<T, A> {
+    state: any
+    lastConfirmedState: any
+    lastConfirmedSeq: number
+    db: DbConnection
+    reducer: (state: any, action: any) => any
+    key: string
+    callback: (state: T) => void
+    sizeThreshold: number
+
+    constructor(opts: ReducerOpts<T, A>) {
+        this.state = structuredClone(opts.initialValue)
+        this.lastConfirmedState = structuredClone(opts.initialValue)
+        this.lastConfirmedSeq = 0
+        this.db = opts.db
+        this.reducer = opts.reducer
+        this.key = opts.key
+        this.callback = opts.callback
+        this.sizeThreshold = opts.sizeThreshold || 30
+
+        this.onSequenceValue = this.onSequenceValue.bind(this)
+        this.onSize = this.onSize.bind(this)
+        this.dispatch = this.dispatch.bind(this)
+
+        this.db.subscribe(this.key, this.onSequenceValue, this.onSize)
+    }
+
+    dispose() {
+        this.db.unsubscribe(this.key, this.onSequenceValue, this.onSize)
+    }
+
+    dispatch(action: A) {
+        this.state = this.reducer(this.state, action)
+        this.db.send({ type: "push", action: { "type": "append" }, value: { "apply": action }, key: this.key })
+
+        this.callback(this.state)
+    }
+
+    onSequenceValue(sequenceValue: SequenceValue) {
+        if (sequenceValue.seq <= this.lastConfirmedSeq) {
+            return;
+        }
+
+        const value = sequenceValue.value as any;
+
+        if (value.reset !== undefined) {
+            this.lastConfirmedState = value.reset as T;
+            this.lastConfirmedSeq = sequenceValue.seq;
+            this.callback(structuredClone(this.lastConfirmedState.current));
+            return;
+        }
+
+        if (value.apply !== undefined) {
+            this.lastConfirmedState = this.reducer(this.lastConfirmedState, value.apply as A);
+            this.lastConfirmedSeq = sequenceValue.seq;
+            this.callback(structuredClone(this.lastConfirmedState));
+            return;
+        }
+
+        console.log("Unknown message", sequenceValue.value)
+    }
+
+    onSize(size: number) {
+        if (size > this.sizeThreshold && this.lastConfirmedSeq !== 0) {
+            this.db?.send({
+                type: "push",
+                action: { "type": "compact", seq: this.lastConfirmedSeq },
+                value: { "reset": this.lastConfirmedState },
+                key: this.key
+            });
+        }
+    }
+}

--- a/js-pkg/driftdb/src/state.ts
+++ b/js-pkg/driftdb/src/state.ts
@@ -1,0 +1,55 @@
+import { DbConnection } from "."
+import { SequenceValue } from "./types"
+
+export class StateListener<T> {
+    lastUpdateSent: number = 0
+    lastValue: T | null = null
+    debounceTimeout: number | null = null
+
+    constructor(
+        private callback: (value: T) => void,
+        private db: DbConnection,
+        private key: string,
+        private debounceMillis: number = 50
+    ) {
+        this.callback = callback.bind(this)
+        this.setStateOptimistic = this.setStateOptimistic.bind(this)
+        this.sendUpdate = this.sendUpdate.bind(this)
+
+        db.subscribe(key, (value: SequenceValue) => {
+            this.callback(value.value as T)
+        })
+    }
+
+    onMessage(value: SequenceValue) {
+        this.callback(value.value as T)
+    }
+
+    sendUpdate() {
+        if (this.debounceTimeout !== null) {
+            window.clearTimeout(this.debounceTimeout)
+            this.debounceTimeout = null
+        }
+        this.db?.send({
+            type: "push",
+            action: { "type": "replace" },
+            value: this.lastValue,
+            key: this.key
+        })
+    }
+
+    setStateOptimistic(value: T) {
+        this.callback(value)
+
+        this.lastValue = value
+        const now = performance.now()
+        if (now - this.lastUpdateSent < this.debounceMillis) {
+            if (this.debounceTimeout === null) {
+                this.debounceTimeout = window.setTimeout(this.sendUpdate, this.debounceMillis)
+            }
+        } else {
+            this.lastUpdateSent = now
+            this.sendUpdate()
+        }
+    }
+}


### PR DESCRIPTION
First step of #22, and also a step on the path to first-class support for non-React frameworks.

- [x] Move logic of `useSharedState` into driftdb
- [x] Move logic of `usePresence` into driftdb
- [x] Move logic of `useUniqueClientID` into driftdb
- [x] Move logic of `useSharedReducer` into driftdb

This will also make the inner logic of these functions more testable, but adding tests is beyond the scope of this PR.