### PR TITLE
Disable cache on build

### DIFF
--- a/js-pkg/turbo.json
+++ b/js-pkg/turbo.json
@@ -3,6 +3,7 @@
   "globalDependencies": ["**/.env.*local"],
   "pipeline": {
     "build": {
+      "cache": false,
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/**"]
     },


### PR DESCRIPTION
driftdb-demos doesn't build from a cache for some reason and this is the easiest fix for now.