### PR TITLE
Fix voxel bug

### DIFF
--- a/js-pkg/apps/demos/src/pages/voxel.tsx
+++ b/js-pkg/apps/demos/src/pages/voxel.tsx
@@ -194,6 +194,8 @@ export function VoxelEditor() {
           voxel: { position, color, opacity: 1 }
         })
       }
+
+      event.stopPropagation()
     },
     [color, dispatch]
   )


### PR DESCRIPTION
R3F gives us a click event for every object a ray hits, so for large scenes we end up sending a bunch of events on clicks. It's  not a correctness issue, because each event tries to draw the same voxel so each one just overwrites the last.