### PR TITLE
Make replay optional

### DIFF
--- a/js-pkg/apps/tests/src/driftdb.test.ts
+++ b/js-pkg/apps/tests/src/driftdb.test.ts
@@ -138,6 +138,57 @@ test('Send and receive binary.', async () => {
   db.disconnect()
 })
 
+test('Subscribe and optionally receive history.', async () => {
+  let { db, room } = await connectToNewRoom()
+
+  let expecter = new CallbackExpecter<SequenceValue>()
+  db.subscribe('key', expecter.accept)
+
+  db.send({
+    type: 'push',
+    key: 'key',
+    action: { type: 'append' },
+    value: 'foo'
+  })
+
+  let result = await expecter.expect('Optimistic set not received.')
+  expect(result).toEqual({
+    seq: 1,
+    value: 'foo'
+  })
+
+  db.disconnect()
+
+  let db2 = await connectToRoom(room)
+  let expecter2 = new CallbackExpecter<SequenceValue>()
+  db2.subscribe('key', expecter2.accept)
+  let result2 = await expecter2.expect('Optimistic set not received.')
+  expect(result2).toEqual({
+    seq: 1,
+    value: 'foo'
+  })
+
+  db2.disconnect()
+
+  // When we disable history, we should not receive the value.
+  let db3 = await connectToRoom(room)
+  let expecter3 = new CallbackExpecter<SequenceValue>()
+  db3.subscribe('key', expecter3.accept, undefined, {replay: false})
+  db3.send({
+    type: 'push',
+    key: 'key',
+    action: { type: 'append' },
+    value: 'bar'
+  })
+  let result3 = await expecter3.expect('Optimistic set not received.')
+  expect(result3).toEqual({
+    seq: 2,
+    value: 'bar'
+  })
+
+  db3.disconnect()
+})
+
 test('Send and receive UInt8Array.', async () => {
   let { db } = await connectToNewRoom({ cbor: true })
 

--- a/js-pkg/packages/driftdb/src/index.ts
+++ b/js-pkg/packages/driftdb/src/index.ts
@@ -14,6 +14,11 @@ export type { DataChannelMsg } from './webrtc'
 
 const CLIENT_ID_KEY = '_driftdb_client_id'
 
+export interface SubscribeOptions {
+  /** Whether to replay history when subscribing. */
+  replay?: boolean
+}
+
 /**
  * A connection to a DriftDB room.
  */
@@ -213,13 +218,16 @@ export class DbConnection {
   subscribe(
     key: Key,
     listener: (event: SequenceValue) => void,
-    sizeCallback?: (size: number) => void
+    sizeCallback?: (size: number) => void,
+    subscribeOptions?: SubscribeOptions
   ) {
     this.subscriptions.subscribe(key, listener)
     if (sizeCallback) {
       this.sizeSubscriptions.subscribe(key, sizeCallback)
     }
-    this.send({ type: 'get', key, seq: 0 })
+    if (subscribeOptions?.replay ?? true) {
+      this.send({ type: 'get', key, seq: 0 })
+    }
   }
 
   /**


### PR DESCRIPTION
When creating a subscription, this allows passing a fourth argument in the form `{replay: false}` which tells driftdb not to replay messages.