### PR TITLE
Implement (flat) pub/sub

### DIFF
--- a/driftdb-server/src/server.rs
+++ b/driftdb-server/src/server.rs
@@ -12,7 +12,7 @@ use driftdb::{Database, MessageFromDatabase, MessageToDatabase};
 use hyper::http::header;
 use hyper::{Method, StatusCode};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::{net::SocketAddr, sync::Arc, fmt::Debug};
+use std::{fmt::Debug, net::SocketAddr, sync::Arc};
 use tower_http::{
     cors::{AllowOrigin, CorsLayer},
     trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer},
@@ -27,7 +27,9 @@ struct TypedWebSocket<Inbound: DeserializeOwned + Debug, Outbound: Serialize + D
     _ph_outbound: std::marker::PhantomData<Outbound>,
 }
 
-impl<Inbound: DeserializeOwned + Debug, Outbound: Serialize + Debug> TypedWebSocket<Inbound, Outbound> {
+impl<Inbound: DeserializeOwned + Debug, Outbound: Serialize + Debug>
+    TypedWebSocket<Inbound, Outbound>
+{
     pub fn new(socket: WebSocket, cbor: bool) -> Self {
         Self {
             socket,
@@ -169,8 +171,9 @@ async fn post_message(
     Json(msg): Json<MessageToDatabase>,
 ) -> std::result::Result<Json<Option<MessageFromDatabase>>, StatusCode> {
     let database = room_map.get(&room_id).ok_or(StatusCode::NOT_FOUND)?;
+    let conn = database.connect(|_| {});
 
-    let result = database.send_message(&msg);
+    let result = conn.send_message(&msg).unwrap();
 
     Ok(Json(result))
 }

--- a/driftdb-worker/src/lib.rs
+++ b/driftdb-worker/src/lib.rs
@@ -271,8 +271,9 @@ impl DurableObject for DbRoom {
             (Method::Get, "connect") => self.connect(req).await,
             (Method::Post, "send") => {
                 let db = self.db.get_db().await?;
+                let conn = db.connect(|_| {});
                 let message: MessageToDatabase = req.json().await?;
-                let response = db.send_message(&message);
+                let response = conn.send_message(&message);
                 Response::from_json(&response)
             }
             _ => Response::error("Room command not found", 404),

--- a/driftdb-worker/src/state.rs
+++ b/driftdb-worker/src/state.rs
@@ -1,10 +1,10 @@
 use crate::Configuration;
+use ciborium::value::Value;
 use driftdb::{
     types::{key_seq_pair::KeyAndSeq, SequenceNumber, SequenceValue},
     ApplyResult, Database, DeleteInstruction, Key, PushInstruction, Store, ValueLog,
 };
 use gloo_utils::format::JsValueSerdeExt;
-use ciborium::value::Value;
 use std::{collections::HashMap, str::FromStr, sync::Arc};
 use worker::{console_log, wasm_bindgen::JsValue, wasm_bindgen_futures};
 use worker::{ListOptions, Result, State};

--- a/driftdb/src/connection.rs
+++ b/driftdb/src/connection.rs
@@ -31,7 +31,12 @@ impl Connection {
             MessageToDatabase::Push { key, value, action } => database.push(key, value, &action),
             MessageToDatabase::Get { seq, key } => {
                 database.subscribe(key, Arc::downgrade(&self));
-                database.get(key, *seq)
+                if let Some(seq) = seq {
+                    // Send prior events on the stream if sequence number is provided.
+                    database.get(key, *seq)
+                } else {
+                    None
+                }
             }
             MessageToDatabase::Ping { nonce } => Some(MessageFromDatabase::Pong { nonce: *nonce }),
         };

--- a/driftdb/src/db.rs
+++ b/driftdb/src/db.rs
@@ -181,7 +181,7 @@ mod tests {
 
     fn subscribe(conn: &Arc<Connection>, key: &str) {
         conn.send_message(&MessageToDatabase::Get {
-            seq: SequenceNumber::default(),
+            seq: Some(SequenceNumber::default()),
             key: key.into(),
         })
         .unwrap();

--- a/driftdb/src/types/mod.rs
+++ b/driftdb/src/types/mod.rs
@@ -81,12 +81,16 @@ pub enum MessageToDatabase {
         /// Key to get.
         key: Key,
         /// Sequence number to start from.
-        #[serde(default)]
-        seq: SequenceNumber,
+        #[serde(default="default_seq")]
+        seq: Option<SequenceNumber>,
     },
     Ping {
         nonce: Option<u64>,
     },
+}
+
+fn default_seq() -> Option<SequenceNumber> {
+    Some(SequenceNumber(0))
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]

--- a/driftdb/src/types/mod.rs
+++ b/driftdb/src/types/mod.rs
@@ -1,5 +1,5 @@
-use serde::{Deserialize, Serialize};
 use ciborium::value::Value;
+use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
 pub mod key_seq_pair;

--- a/js-pkg/packages/driftdb/src/index.ts
+++ b/js-pkg/packages/driftdb/src/index.ts
@@ -254,9 +254,9 @@ export class DbConnection {
     if (sizeCallback) {
       this.sizeSubscriptions.subscribe(key, sizeCallback)
     }
-    if (subscribeOptions?.replay ?? true) {
-      this.send({ type: 'get', key, seq: 0 })
-    }
+    let replay = subscribeOptions?.replay ?? true
+    let seq = replay ? 0 : null
+    this.send({ type: 'get', key, seq })
   }
 
   /**

--- a/js-pkg/packages/driftdb/src/tests/driftdb.test.ts
+++ b/js-pkg/packages/driftdb/src/tests/driftdb.test.ts
@@ -17,7 +17,7 @@ class CallbackExpecter<T> {
     private nextValue: T | null = null
     private timeout: number | null = null
 
-    expect(message: string, timeoutMillis = 5_000): Promise<T> {
+    expect(message: string, timeoutMillis = 3_000): Promise<T> {
         if (this.nextValue) {
             const value = this.nextValue
             this.nextValue = null

--- a/js-pkg/packages/driftdb/src/types.ts
+++ b/js-pkg/packages/driftdb/src/types.ts
@@ -46,7 +46,7 @@ export type MessageToDb =
   | {
       type: 'get'
       key: Key
-      seq?: SequenceNumber
+      seq?: SequenceNumber | null
     }
   | {
       type: 'ping'

--- a/test.sh
+++ b/test.sh
@@ -12,4 +12,4 @@ cargo run &
 
 cd ${BASE_DIR}/js-pkg/packages/driftdb
 npm ci --include=dev
-npm test
+npm test -- --detectOpenHandles

--- a/test.sh
+++ b/test.sh
@@ -12,4 +12,4 @@ cargo run &
 
 cd ${BASE_DIR}/js-pkg/packages/driftdb
 npm ci --include=dev
-npm test -- --detectOpenHandles
+npm test -- --forceExit --detectOpenHandles


### PR DESCRIPTION
Previously, every connection would receive every message, even though client-side there is a concept of a subscription. This moves the concept of a subscription into the database.

The `Get` message is now a misnomer because it both gets the value, and creates a subscription to it.