### PR TITLE
Add support for React v19

### DIFF
--- a/js-pkg/packages/driftdb-react/package.json
+++ b/js-pkg/packages/driftdb-react/package.json
@@ -18,7 +18,7 @@
     "@types/react": "^18.0.27"
   },
   "peerDependencies": {
-    "react": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0"
   },
   "homepage": "https://driftdb.com",
   "repository": {


### PR DESCRIPTION
Add support for React v19 for JavaScript package `driftdb-react`

See https://react.dev/blog/2024/12/05/react-19